### PR TITLE
release: prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.1.0
+
+- Update the `openapi` spec and regenerate the SDK. Thanks [@pranav-okta](https://github.com/pranav-okta)
+
 ## v1.0.1
 
 - Fixes bug in Get and List Entitlement Bundles APIs. Thanks [@aditya-okta](https://github.com/aditya-okta).

--- a/governance/client.go
+++ b/governance/client.go
@@ -69,7 +69,7 @@ var (
 )
 
 const (
-	VERSION                   = "1.0.1"
+	VERSION                   = "1.1.0"
 	AccessTokenCacheKey       = "OKTA_ACCESS_TOKEN"
 	DpopAccessTokenNonce      = "DPOP_OKTA_ACCESS_TOKEN_NONCE"
 	DpopAccessTokenPrivateKey = "DPOP_OKTA_ACCESS_TOKEN_PRIVATE_KEY"

--- a/governance/configuration.go
+++ b/governance/configuration.go
@@ -105,7 +105,7 @@ type Configuration struct {
 func NewConfiguration() *Configuration {
 	cfg := &Configuration{
 		DefaultHeader: make(map[string]string),
-		UserAgent:     "OpenAPI-Generator/1.0.1/go",
+		UserAgent:     "OpenAPI-Generator/1.1.0/go",
 		Debug:         false,
 		Servers: ServerConfigurations{
 			{


### PR DESCRIPTION
## v1.1.0

- Update the `openapi` spec and regenerate the SDK. Thanks [@pranav-okta](https://github.com/pranav-okta)