### PR TITLE
fix: surface error detail in GenericOpenAPIError.Error()

### DIFF
--- a/.generator/templates/client.mustache
+++ b/.generator/templates/client.mustache
@@ -1365,6 +1365,36 @@ type GenericOpenAPIError struct {
 
 // Error returns non-empty string if there was an error.
 func (e GenericOpenAPIError) Error() string {
+	if e.model != nil {
+		if apiErr, ok := e.model.(*ModelError); ok {
+			msg := e.error
+			if summary := apiErr.GetErrorSummary(); summary != "" {
+				msg = fmt.Sprintf("%s: %s", e.error, summary)
+			}
+			var meta []string
+			if code := apiErr.GetErrorCode(); code != "" {
+				meta = append(meta, fmt.Sprintf("errorCode: %s", code))
+			}
+			if id := apiErr.GetErrorId(); id != "" {
+				meta = append(meta, fmt.Sprintf("errorId: %s", id))
+			}
+			if len(meta) > 0 {
+				msg = fmt.Sprintf("%s (%s)", msg, strings.Join(meta, ", "))
+			}
+			if causes := apiErr.GetErrorCauses(); len(causes) > 0 {
+				causeMessages := make([]string, 0, len(causes))
+				for _, cause := range causes {
+					if cs := cause.GetErrorSummary(); cs != "" {
+						causeMessages = append(causeMessages, cs)
+					}
+				}
+				if len(causeMessages) > 0 {
+					msg = fmt.Sprintf("%s. Causes: %s", msg, strings.Join(causeMessages, ", "))
+				}
+			}
+			return msg
+		}
+	}
 	return e.error
 }
 

--- a/governance/client.go
+++ b/governance/client.go
@@ -1404,6 +1404,36 @@ type GenericOpenAPIError struct {
 
 // Error returns non-empty string if there was an error.
 func (e GenericOpenAPIError) Error() string {
+	if e.model != nil {
+		if apiErr, ok := e.model.(*ModelError); ok {
+			msg := e.error
+			if summary := apiErr.GetErrorSummary(); summary != "" {
+				msg = fmt.Sprintf("%s: %s", e.error, summary)
+			}
+			var meta []string
+			if code := apiErr.GetErrorCode(); code != "" {
+				meta = append(meta, fmt.Sprintf("errorCode: %s", code))
+			}
+			if id := apiErr.GetErrorId(); id != "" {
+				meta = append(meta, fmt.Sprintf("errorId: %s", id))
+			}
+			if len(meta) > 0 {
+				msg = fmt.Sprintf("%s (%s)", msg, strings.Join(meta, ", "))
+			}
+			if causes := apiErr.GetErrorCauses(); len(causes) > 0 {
+				causeMessages := make([]string, 0, len(causes))
+				for _, cause := range causes {
+					if cs := cause.GetErrorSummary(); cs != "" {
+						causeMessages = append(causeMessages, cs)
+					}
+				}
+				if len(causeMessages) > 0 {
+					msg = fmt.Sprintf("%s. Causes: %s", msg, strings.Join(causeMessages, ", "))
+				}
+			}
+			return msg
+		}
+	}
 	return e.error
 }
 


### PR DESCRIPTION
## Summary

- `GenericOpenAPIError.Error()` previously returned only the raw HTTP status text (e.g. `401 Unauthorized`), making it difficult to diagnose API failures
- When the model is a `*ModelError`, the method now returns a structured message including the error summary, error code, error ID, and any error causes
- Falls back to the existing behavior for non-`ModelError` types or nil models
- Updated both the Mustache template and the generated `client.go`

## Example

Before: `401 Unauthorized`

After: `401 Unauthorized: Authentication failed (errorCode: E0000011, errorId: abc123). Causes: Invalid token provided`